### PR TITLE
Added 'content' to allowed uri types

### DIFF
--- a/index.js
+++ b/index.js
@@ -112,7 +112,7 @@ class PdfReader extends Component<Props, State> {
       this.setState({ ios, android })
 
       let data = undefined
-      if(source.uri && source.uri.startsWith('http') || source.uri && source.uri.startsWith('file')) {
+      if(source.uri && (source.uri.startsWith('http') || source.uri.startsWith('file') || source.uri.startsWith('content'))) {
         data = await fetchPdfAsync(source.uri)
       } else if (source.base64 && source.base64.startsWith('data')) {
         data = source.base64

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rn-pdf-reader-js",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "PDF reader for Expo",
   "main": "index.js",
   "author": "Xavier Carpentier <xcapetir@gmail.com> (https://xaviercarpentier.com/)",


### PR DESCRIPTION
hotfix to allow content:// as a valid uri format, i.e:

`content://com.android.externalstorage.documents/...`