### PR TITLE
The loader is never shown in iOs when a pdf URI is used

### DIFF
--- a/index.js
+++ b/index.js
@@ -183,6 +183,7 @@ class PdfReader extends Component<Props, State> {
         <View style={[styles.container, style]}>
           {!ready && <Loader />}
           <WebView
+            onLoad={()=>this.setState({ready: true})}
             originWhitelist={['http://*', 'https://*', 'file://*', 'data:*']}
             style={styles.webview}
             source={{ uri: data }}

--- a/index.js
+++ b/index.js
@@ -132,7 +132,7 @@ class PdfReader extends Component<Props, State> {
       const android = Platform.OS === 'android'
 
       this.setState({ ios, android })
-
+      let ready = false
       let data = undefined
       if (
         source.uri &&
@@ -142,8 +142,10 @@ class PdfReader extends Component<Props, State> {
           source.uri.startsWith('content'))
       ) {
         data = await fetchPdfAsync(source.uri)
+        ready= !!data
       } else if (source.base64 && source.base64.startsWith('data')) {
         data = source.base64
+        ready = true
       } else if (ios) {
         data = source.uri
       } else {
@@ -155,7 +157,7 @@ class PdfReader extends Component<Props, State> {
         await writeWebViewReaderFileAsync(data)
       }
 
-      this.setState({ ready: !!data, data })
+      this.setState({ ready, data })
     } catch (error) {
       alert('Sorry, an error occurred.')
       console.error(error)
@@ -176,9 +178,10 @@ class PdfReader extends Component<Props, State> {
     const { ready, data, ios, android } = this.state
     const { style } = this.props
 
-    if (ready && data && ios) {
+    if (data && ios) {
       return (
         <View style={[styles.container, style]}>
+          {!ready && <Loader />}
           <WebView
             originWhitelist={['http://*', 'https://*', 'file://*', 'data:*']}
             style={styles.webview}


### PR DESCRIPTION
In iOs the PDF viewer is the system webview without download the file, but the loader was never shown because is based on the value of the data var, witch in iOs is the url so always is true.

The ready state var has been changed to be setted to true only in base64 and android url files. In iOs is setted to true when the webview onLoad method is fired.

