### PR TITLE
Additional props introduced: webviewStyle, onLoad, noLoader

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,9 @@ const styles = StyleSheet.create({
   * uri?: `string` - can be local or served on the web (ie. start withs `https://` or `file://`)
   * base64?: `string` - should start with `data`
 * style: `object` - style props to override default container style
+* webviewStyle: `object` - style props to override default WebView style
+* onLoad: `func` - callback that runs after WebView is loaded
+* noLoader: `boolean` - show/hide the ActivityIndicator. Default is false
 
 ## Requirements
 * Use it into Expo app (from expo client, Standalone app or ExpoKit app).


### PR DESCRIPTION
I have introduced 3 more props:

* webviewStyle : Now you can override the webview's style such as background colour(which was always grey colour to something else.)
* onLoad : Optional callback to be run when WebView is loaded. Tested on both Android and iOS.(And it should work because WebView that this repo is using is the one from ReactNative and onLoad is one of those props that's allowed by RN's WebView)
* noLoader : Sometimes loader is not needed (especially when there is custom loader). Boolean, and true value will hide it.