### PR TITLE
Modular imports for Expo SDK 33

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,8 +7,8 @@ import {
   Platform,
   StyleSheet,
 } from 'react-native'
-import { FileSystem } from 'expo'
-import { Constants } from 'expo'
+import * as FileSystem from 'expo-file-system'
+import Constants from 'expo-constants'
 
 const {
   cacheDirectory,

--- a/package.json
+++ b/package.json
@@ -24,6 +24,8 @@
   },
   "peerDependencies": {
     "expo": "*",
+    "expo-constants": "*",
+    "expo-file-system": "*",
     "react": "*",
     "react-native": "*"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -17,6 +17,20 @@ crypto@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/crypto/-/crypto-1.0.1.tgz#2af1b7cad8175d24c8a1b0778255794a21803037"
 
+expo-constants@*:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/expo-constants/-/expo-constants-5.0.1.tgz#597263397f269d7fe37d9cd6b30e305c16635a00"
+  integrity sha512-Ny3teALKaE/jFzBg6DHr2GOoHpwQ/OLs3q3VugZOoR6hXCeVcCEP9MyNvhgn/cheeBDAa6UIgarv2Yufb5RMqQ==
+  dependencies:
+    ua-parser-js "^0.7.19"
+
+expo-file-system@*:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/expo-file-system/-/expo-file-system-5.0.1.tgz#c26054e512c3bb2e256325b48e603957a24e6210"
+  integrity sha512-8AD8Tt0vR8XNIPXOg5akPUPGuf+SCiE9kY5JppUwfJtfIsiH3BZnebu1bkYCVOMojSgFA017kr8VmH57vEWdnQ==
+  dependencies:
+    uuid-js "^0.7.5"
+
 flow-bin@0.73.0:
   version "0.73.0"
   resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.73.0.tgz#da1b90a02b0ef9c439f068c2fc14968db83be425"
@@ -28,3 +42,13 @@ ieee754@^1.1.4:
 js-base64@2.4.5:
   version "2.4.5"
   resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-2.4.5.tgz#e293cd3c7c82f070d700fc7a1ca0a2e69f101f92"
+
+ua-parser-js@^0.7.19:
+  version "0.7.20"
+  resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.20.tgz#7527178b82f6a62a0f243d1f94fd30e3e3c21098"
+  integrity sha512-8OaIKfzL5cpx8eCMAhhvTlft8GYF8b2eQr6JkCyVdrgjcytyOmPCXrqXFcUnhonRpLlh5yxEZVohm6mzaowUOw==
+
+uuid-js@^0.7.5:
+  version "0.7.5"
+  resolved "https://registry.yarnpkg.com/uuid-js/-/uuid-js-0.7.5.tgz#6c886d02a53d2d40dcf25d91a170b4a7b25b94d0"
+  integrity sha1-bIhtAqU9LUDc8l2RoXC0p7JblNA=


### PR DESCRIPTION
Hi!

I updated Expo to [SDK 33](https://blog.expo.io/expo-sdk-v33-0-0-is-now-available-52d1c99dfe4c), but started getting these deprecation warnings:

```
The following APIs have moved to separate packages and importing them from the "expo" package is deprecated: Constants, FileSystem.

1. Add correct versions of these packages to your project using:

   expo install expo-constants expo-file-system

   If "install" is not recognized as an expo command, update your expo-cli installation.

2. Change your imports so they use specific packages instead of the "expo" package:

 - import { Constants } from 'expo' -> import Constants from 'expo-constants'
 - import { FileSystem } from 'expo' -> import * as FileSystem from 'expo-file-system'
```

This PR simply adds `expo-constants` and `expo-file-system` as peer dependencies and replaces the `from 'expo'` imports in `index.js` with their modular counterparts.

I tested this in my [fork](https://github.com/doshidak/rn-pdf-reader-js) and no more warnings! :)