### PR TITLE
Fixes ERR_ACCESS_DENIED on Android

### DIFF
--- a/index.js
+++ b/index.js
@@ -211,6 +211,7 @@ class PdfReader extends Component<Props, State> {
           <WebView
             onLoad={onLoad}
             allowFileAccess
+            originWhitelist={['http://*', 'https://*', 'file://*', 'data:*']}
             style={[styles.webview, webviewStyle]}
             source={{ uri: htmlPath }}
             mixedContentMode="always"


### PR DESCRIPTION
I'm receiving the error `net::ERR_ACCESS_DENIED` on Android using the Expo SDK 33.

I noticed the error was related to the origin whitelist, this PR adds the same whitelist being used on iOS, which fixes the issue.