### PR TITLE
Added onLoadEnd and onErrors webview props to Android

### DIFF
--- a/index.js
+++ b/index.js
@@ -184,7 +184,7 @@ class PdfReader extends Component<Props, State> {
 
   render() {
     const { ready, data, ios, android } = this.state
-    const { style, webviewStyle, onLoad, noLoader } = this.props
+    const { style, webviewStyle, onLoad, noLoader, onLoadEnd, onError  } = this.props
 
     if (data && ios) {
       return (
@@ -210,6 +210,8 @@ class PdfReader extends Component<Props, State> {
         <View style={[styles.container, style]}>
           <WebView
             onLoad={onLoad}
+            onLoadEnd={onLoadEnd}
+            onError={onError}
             allowFileAccess
             originWhitelist={['http://*', 'https://*', 'file://*', 'data:*']}
             style={[styles.webview, webviewStyle]}


### PR DESCRIPTION
Hi! I needed both Webview onLoadEnd and onErrors props for a feature on a project I'm working with and I could test it only on Android (that's why I didn't replicate the code to iOs). That's also my first PR, so, if it needs any change just tell me. Thanks for the package.