### PR TITLE
Feat/types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,26 @@
+declare module 'rn-pdf-reader-js' {
+  import { Component } from "react";
+  import { StyleProp, ViewStyle, NavState } from 'react-native';
+
+  interface IProps {
+    source: {
+      uri?: string,
+      base64?: string
+    },
+    style?: StyleProp<ViewStyle>,
+    webviewStyle?: StyleProp<ViewStyle>,
+    onLoad?: (event: NavState) => void,
+    noLoader?: boolean
+  }
+  
+  interface IState {
+    ready: boolean,
+    android: boolean,
+    ios: boolean,
+    data?: string,
+  }
+
+  export function removeFilesAsync(): Promise<void>;
+  
+  export default class PdfReader extends Component<IProps, IState> {}
+}

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.3.0",
   "description": "PDF reader for Expo",
   "main": "index.js",
+  "types": "index.d.ts",
   "author": "Xavier Carpentier <xcapetir@gmail.com> (https://xaviercarpentier.com/)",
   "license": "MIT",
   "scripts": {


### PR DESCRIPTION
Introduced typing file for rn-pdf-reader-js so that typescript projects can easily use that without error `Unable to find declaration file for 'rn-pdf-reader-js'`

fixes #60 