### PR TITLE
Add flag to always use the html viewer even on iOS where the native PDF is much better.

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ interface Props {
   noLoader?: boolean
   useGoogleReader?: boolean // If you are not worried about confidentiality
   withScroll?: boolean // Can cause performance issue
+  alwaysUseHtmlViewer?: boolean; // always uses html viewer even when native pdf viewer is available (i.e. iOS)
   customStyle?: {
     readerContainer?: CSS.Properties
     readerContainerDocument?: CSS.Properties
@@ -84,11 +85,12 @@ interface Props {
 
 ## Possibilities
 
-| Render type         | Platform     | Source prop   |
-| ------------------- | ------------ | ------------- |
-| Custom PDF reader   | Android      | uri or base64 |
-| Direct from WebView | iOS          | uri or base64 |
-| Google PDF Reader   | Android, iOS | uri           |
+| Render type         | Platform     | Source prop   | AlwaysUseHtmlViewer prop |
+|---------------------|--------------|---------------|--------------------------|
+| Custom PDF reader   | Android      | uri or base64 | any                      |
+| Custom PDF reader   | iOS          | uri or base64 | true                     |
+| Direct from WebView | iOS          | uri or base64 | false / undefined        |
+| Google PDF Reader   | Android, iOS | uri           | false / undefined        |
 
 ## What rn-pdf-reader-js use?
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -51,6 +51,7 @@ export interface Props {
   customStyle?: CustomStyle
   useGoogleReader?: boolean
   withScroll?: boolean
+  alwaysUseHtmlViewer?: boolean
   onLoad?(event: WebViewNavigationEvent): void
   onLoadEnd?(event: WebViewNavigationEvent | WebViewErrorEvent): void
   onError?(event: WebViewErrorEvent | WebViewHttpErrorEvent | string): void
@@ -291,18 +292,21 @@ class PdfReader extends React.Component<Props, State> {
     const {
       useGoogleReader,
       source: { uri, base64 },
+      alwaysUseHtmlViewer
     } = this.props
 
     if (useGoogleReader) {
       return 'GOOGLE_READER'
     }
 
-    if (Platform.OS === 'ios') {
-      if (uri !== undefined) {
-        return 'DIRECT_URL'
-      }
-      if (base64 !== undefined) {
-        return 'BASE64_TO_LOCAL_PDF'
+    if(!alwaysUseHtmlViewer) {
+      if (Platform.OS === 'ios') {
+        if (uri !== undefined) {
+          return 'DIRECT_URL'
+        }
+        if (base64 !== undefined) {
+          return 'BASE64_TO_LOCAL_PDF'
+        }
       }
     }
 


### PR DESCRIPTION
This is used by some legacy applications who have a very tight integration with the WebView

For ticket #99 