### PR TITLE
Update Expo peer dependency version

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,10 +34,10 @@
     "url": "git+https://github.com/xcarpentier/rn-pdf-reader-js.git"
   },
   "peerDependencies": {
-    "expo": ">= 33.0.x < 41.0.x",
-    "expo-constants": ">= 5.0.0 < 9.x",
-    "expo-file-system": ">= 5.0.0 < 9.x",
-    "react": "16.x",
+    "expo": ">= 33.0.x < 46.0.x",
+    "expo-constants": ">= 5.0.0 < 14.x",
+    "expo-file-system": ">= 5.0.0 < 15.x",
+    "react": ">= 16.x < 18",
     "react-native": "*",
     "react-native-webview": ">= 7.0.5 < 12.x"
   },


### PR DESCRIPTION
Hello !
First, thank you for this library! I'm using it and it's awesome.

I was having issues with `npm install` after upgrading to Expo v45.
I updated the versions in the peerDependencies section so that it works again. Tested with Node v16.13.0 with NPM v8.11.0.

I'm using my own version as a dependency for my projects while this is being reviewed.

Thank you!