### PR TITLE
fix: 🐛 changing to an object with the undefined property to avoid an error on the android platform

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -475,7 +475,7 @@ class PdfReader extends React.Component<Props, State> {
               onError,
               onHttpError: onError,
               style,
-              source: renderedOnce || !isAndroid ? source : undefined,
+              source: renderedOnce || !isAndroid ? source : {uri: undefined},
             }}
             allowFileAccess={isAndroid}
             allowFileAccessFromFileURLs={isAndroid}


### PR DESCRIPTION
### Fix for the error that it is not possible to convert the null value to an object (Plataform: ANDROID)


#### Explanation:
When using the library on the Android platform, in the source property when placing an object and running the app, when rendering the pdf file, an error is returned saying that it is not possible to convert a null value to an object, as shown in this image:


![bug](https://github.com/xcarpentier/rn-pdf-reader-js/assets/22460976/9c5a7e63-29c5-4c42-a67c-e8d04bac8c73)

